### PR TITLE
Fix to log statement.

### DIFF
--- a/src/protocol_proxy/protocol/bacnet/bacnet.py
+++ b/src/protocol_proxy/protocol/bacnet/bacnet.py
@@ -157,7 +157,7 @@ class BACnet:
                 int(priority)
             )
         except ErrorRejectAbortNack as e:
-            print(str(e))
+            _log.debug(str(e))
 
     # async def write_property_multiple(self, device_address: str, write_specifications: list):
     #     # TODO Implement write_property_multiple.  Commenting until completed.


### PR DESCRIPTION
This pull request makes a minor improvement to the logging in the BACnet protocol implementation by replacing a print statement with a debug log call. This helps ensure that error messages are properly managed and can be filtered based on log level.

* Logging improvements:
  * Replaced a `print` statement with a `_log.debug` call in the error handling of the `write_property` method in `bacnet.py`.